### PR TITLE
Add floating timer for scrolling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -143,6 +143,17 @@ main {
     color: #856404;
 }
 
+/* Timer compact et fixé lors du défilement */
+.timer-fixed {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.9rem;
+    z-index: 1000;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
 /* ========== Résultats ========== */
 #results {
     background: #f8f9fa;

--- a/js/main.js
+++ b/js/main.js
@@ -15,10 +15,12 @@ const scorePara = document.getElementById('score');
 const correctionDiv = document.getElementById('correction');
 const retryBtn = document.getElementById('retry-btn');
 const timerDisplay = document.getElementById('timer-display');
+const timerContainer = document.getElementById('timer-container');
 
 /* --- Timer (1h15) --- */
 let timeRemaining = 75 * 60; // 75 minutes en secondes
 let timerInterval; // pour stocker l'intervalle
+let timerOffsetTop = 0; // position initiale du minuteur
 
 /**
  * Variables globales :
@@ -109,6 +111,7 @@ async function startExam() {
 
     displayQuestions(selectedQuestions);
     submitBtn.style.display = "inline-block";
+    updateTimerOffset();
 }
 
 /**
@@ -351,9 +354,28 @@ function updateTimerDisplay(seconds) {
     timerDisplay.textContent = `${hh}:${mm}:${ss}`;
 }
 
+// Met à jour la position de référence du minuteur
+function updateTimerOffset() {
+    if (timerContainer) {
+        timerOffsetTop = timerContainer.offsetTop;
+    }
+}
+
+// Ajuste la classe du minuteur en fonction du défilement
+function handleTimerPosition() {
+    if (!timerContainer) return;
+    if (window.scrollY > timerOffsetTop) {
+        timerContainer.classList.add('timer-fixed');
+    } else {
+        timerContainer.classList.remove('timer-fixed');
+    }
+}
+
 /* ================================
     GESTION DES ÉVÉNEMENTS
    ================================ */
 startBtn.addEventListener('click', startExam);
 submitBtn.addEventListener('click', submitExam);
 retryBtn.addEventListener('click', retryExam);
+window.addEventListener('scroll', handleTimerPosition);
+window.addEventListener('resize', updateTimerOffset);


### PR DESCRIPTION
## Summary
- keep the timer element reference and position in JS
- fix the timer in the corner on scroll
- style the compact timer when fixed

## Testing
- `npm test` *(fails: missing `package.json`)*