### PR TITLE
Switch vendor libraries to CDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ python3 -m http.server 8000
 
 Run this command from the project root and then open <http://localhost:8000/> in your browser. The `index.html` file will load and the quiz interface will appear.
 
+This version loads external libraries from public CDNs. An active Internet connection is therefore required while using the application.
+
 ## JSON data format
 
 Questions are organized per chapter. Each `chaptX.json` file contains a structure similar to:

--- a/index.html
+++ b/index.html
@@ -10,19 +10,19 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 
     <!-- === Tailwind CSS === -->
-    <link href="vendor/css/tailwind.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.2/dist/tailwind.min.css" rel="stylesheet">
 
     <!-- === Bootstrap 5 === -->
-    <link href="vendor/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- === Animate.css === -->
-    <link rel="stylesheet" href="vendor/css/animate.min.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
 
     <!-- === AOS (Animate On Scroll) === -->
-    <link rel="stylesheet" href="vendor/css/aos.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css">
 
     <!-- === Font Awesome (pour les icônes) === -->
-    <link rel="stylesheet" href="vendor/css/fontawesome.min.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
 
     <!-- === Votre feuille de style === -->
     <link rel="stylesheet" href="css/style.css">
@@ -97,12 +97,12 @@
     <p class="mb-0"><i class="fas fa-copyright"></i> 2025 - Développé par Belhaj Ouajdi</p>
 </footer>
 <!-- === Bibliothèques JavaScript === -->
-<script src="vendor/js/bootstrap.bundle.min.js"></script>
-<script src="vendor/js/aos.js"></script>
-<script src="vendor/js/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked@4.3.0/marked.min.js"></script>
 
 <!-- === JSTable pour l'affichage des tableaux === -->
-<script src="vendor/js/jstable.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jstable@1.0/jstable.min.js"></script>
 <!-- === Scripts du projet === -->
 <script src="js/utils.js"></script>
 <script src="js/main.js"></script>

--- a/vendor/css/animate.min.css
+++ b/vendor/css/animate.min.css
@@ -1,1 +1,0 @@
-/* Placeholder for Animate.css - offline version */

--- a/vendor/css/aos.css
+++ b/vendor/css/aos.css
@@ -1,1 +1,0 @@
-/* Placeholder for AOS CSS - offline version */

--- a/vendor/css/bootstrap.min.css
+++ b/vendor/css/bootstrap.min.css
@@ -1,1 +1,0 @@
-/* Placeholder for Bootstrap CSS - offline version */

--- a/vendor/css/fontawesome.min.css
+++ b/vendor/css/fontawesome.min.css
@@ -1,1 +1,0 @@
-/* Placeholder for Font Awesome CSS - offline version */

--- a/vendor/css/tailwind.min.css
+++ b/vendor/css/tailwind.min.css
@@ -1,1 +1,0 @@
-/* Placeholder for Tailwind CSS - offline version */

--- a/vendor/js/aos.js
+++ b/vendor/js/aos.js
@@ -1,1 +1,0 @@
-/* Placeholder for AOS JS - offline version */

--- a/vendor/js/bootstrap.bundle.min.js
+++ b/vendor/js/bootstrap.bundle.min.js
@@ -1,1 +1,0 @@
-/* Placeholder for Bootstrap Bundle JS - offline version */

--- a/vendor/js/jstable.min.js
+++ b/vendor/js/jstable.min.js
@@ -1,1 +1,0 @@
-/* Placeholder for JSTable JS - offline version */

--- a/vendor/js/marked.min.js
+++ b/vendor/js/marked.min.js
@@ -1,1 +1,0 @@
-/* Placeholder for marked.js - offline version */


### PR DESCRIPTION
## Summary
- use CDN links for Bootstrap, Tailwind, Animate.css, AOS, Font Awesome
- remove offline `vendor/` placeholders
- note in README that libraries are now loaded from CDNs

## Testing
- `git status`