### PR TITLE
Improve timer positioning after AOS animation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -205,3 +205,10 @@ main {
 .fade-in {
     animation: fadeIn 0.4s ease-out;
 }
+
+/* ==== AOS Fixes ==== */
+/* Après l'animation d'apparition, on réinitialise toute transformation
+   appliquée à la section d'examen pour éviter tout décalage persistant. */
+#exam.aos-animate {
+    transform: none !important;
+}

--- a/index.html
+++ b/index.html
@@ -109,7 +109,9 @@
 
 <script>
     document.addEventListener('DOMContentLoaded', function() {
-        AOS.init({ once: false, mirror: false });
+        // On joue l'animation AOS une seule fois afin que la section d'examen
+        // ne réapplique pas de transformation lors du défilement.
+        AOS.init({ once: true, mirror: false });
     });
 </script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -105,6 +105,12 @@ async function startExam() {
     timeRemaining = 75 * 60;
     startTimer();
 
+    // Une fois l'animation d'apparition du minuteur terminée,
+    // on recalcule sa position de référence pour le comportement fixe.
+    if (timerContainer) {
+        timerContainer.addEventListener('animationend', updateTimerOffset, { once: true });
+    }
+
     selectedQuestions = await loadQuestionsFromMultipleJson();
     if (selectedQuestions.length < 40) {
         console.warn("Le total de questions récupérées est inférieur à 40 !");


### PR DESCRIPTION
## Summary
- run AOS only once so transforms don't reapply
- recalc timer offset after its animation to keep it fixed

## Testing
- `git status --short`