### PR TITLE
Replace Tailwind CSS stylesheet link with CDN script

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 
     <!-- === Tailwind CSS === -->
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.2/dist/tailwind.min.css" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
 
     <!-- === Bootstrap 5 === -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- switch from `<link>` to CDN script for Tailwind CSS

## Testing
- `python3 -m http.server 8000` *(serves the page)*
- `curl -s http://localhost:8000/index.html | head`