### PR TITLE
Ajout du temps au message de résultat

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,6 @@
     <section id="results" class="hidden mt-5 animate-zoom-in" data-aos="zoom-in" data-aos-duration="700">
         <h2 class="text-center mb-4 text-3xl font-semibold animate__animated animate__fadeInDown">Résultats</h2>
         <p id="score" class="fs-5 text-center"></p>
-        <p id="time-used" class="fs-6 text-muted text-center"></p>
         <div id="correction" class="mt-3">
             <!-- Détails des résultats -->
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -19,7 +19,8 @@ const timerContainer = document.getElementById('timer-container');
 
 
 /* --- Timer (1h15) --- */
-let timeRemaining = 75 * 60; // 75 minutes en secondes
+const EXAM_DURATION = 75 * 60; // durée totale de l'examen en secondes (75 min)
+let timeRemaining = EXAM_DURATION; // temps restant en secondes
 let timerInterval; // pour stocker l'intervalle
 let timerOffsetTop = 0; // position initiale du minuteur
 
@@ -103,7 +104,7 @@ async function startExam() {
     introSection.classList.add('hidden');
     examSection.classList.remove('hidden');
 
-    timeRemaining = 75 * 60;
+    timeRemaining = EXAM_DURATION;
     startTimer();
 
     // Une fois l'animation d'apparition du minuteur terminée,
@@ -272,7 +273,15 @@ function showResults(score) {
     const totalQuestions = selectedQuestions.length; // Doit être 40
     const pourcentage = ((score / totalQuestions) * 100).toFixed(2);
 
-    scorePara.textContent = `Vous avez obtenu ${score}/${totalQuestions} (${pourcentage}%).`;
+    // Calcul du temps utilisé et du pourcentage consommé
+    const timeUsedSec = EXAM_DURATION - timeRemaining;
+    const minutesUsed = Math.floor(timeUsedSec / 60);
+    const secondsUsed = timeUsedSec % 60;
+    const percentUsed = ((timeUsedSec / EXAM_DURATION) * 100).toFixed(2);
+
+    const baseText = `Vous avez obtenu ${score}/${totalQuestions} (${pourcentage}%).`;
+    const timeText = ` Temps utilisé : ${minutesUsed}m${secondsUsed.toString().padStart(2, '0')}s (${percentUsed}% du temps).`;
+    scorePara.textContent = baseText + timeText;
 
     const threshold = 26;
     if (score >= threshold) {


### PR DESCRIPTION
## Notes
- Aucun test automatisé n'est fourni pour cette application web statique.

## Summary
- supprime l'élément dédié au temps et le code associé
- ajoute la durée consommée directement dans la phrase du résultat

## Testing
- ❌ `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`