### PR TITLE
Change v4 to V4 in exam title

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
     <meta charset="UTF-8">
-    <title>EvaluaTest - Examen blanc ISTQB v4 Foundation Level</title>
+    <title>EvaluaTest - Examen blanc ISTQB V4 Foundation Level</title>
 
     <!-- === Google Fonts - Roboto === -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -67,14 +67,14 @@
 <header class="text-center p-4 mb-3 bg-primary text-white animate__animated animate__fadeInDown">
 
         <h1 class="mb-1 text-1xl md:text-6xl font-bold"><i class="fas fa-graduation-cap"></i> EvaluaTest</h1>
-    <p class="mb-0">Examen blanc ISTQB v4 Foundation Level</p>
+    <p class="mb-0">Examen blanc ISTQB V4 Foundation Level</p>
 </header>
 
 <main class="container mb-5">
     <section id="intro" class="text-center mb-5 animate__animated animate__fadeInUp animate-fade-up" data-aos="zoom-in" data-aos-duration="800">
         <p class="mb-4">
             Bienvenue sur <strong>EvaluaTest</strong>, la plateforme d’examens blancs
-            pour la certification <strong>ISTQB v4 Foundation Level</strong>.<br>
+            pour la certification <strong>ISTQB V4 Foundation Level</strong>.<br>
             Cliquez sur le bouton ci-dessous pour commencer votre examen.
         </p>
         <button id="start-btn" class="btn btn-success btn-lg px-4 mt-3 animate__animated animate__pulse animate__infinite transition-transform hover:scale-105">

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 /********************************************
  * main.js
  * Fichier JavaScript principal pour EvaluaTest
- * (Examens blancs ISTQB v4 Foundation Level)
+ * (Examens blancs ISTQB V4 Foundation Level)
  ********************************************/
 
 /* --- Sélection des éléments HTML --- */

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,7 +1,7 @@
 /********************************************
  * utils.js
  * Fonctions utilitaires pour EvaluaTest
- * (Examens blancs ISTQB v4 Foundation Level)
+ * (Examens blancs ISTQB V4 Foundation Level)
  ********************************************/
 
 /**


### PR DESCRIPTION
## Summary
- correct capitalization from `v4` to `V4` in title text and HTML header
- update comments referencing exam name in JS files

## Testing
- `git status --short`