### PR TITLE
Séparer l'affichage du score et du temps dans les résultats

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -298,7 +298,8 @@ function showResults(score) {
     const percentUsed = ((timeUsedSec / EXAM_DURATION) * 100).toFixed(2);
     const baseText = `Vous avez obtenu ${score}/${totalQuestions} (${pourcentage}%).`;
     const timeText = ` Temps utilisé : ${minutesUsed}m${secondsUsed.toString().padStart(2, '0')}s (${percentUsed}% du temps).`;
-    scorePara.textContent = baseText + timeText;
+    scorePara.textContent = baseText;
+    timeUsedPara.textContent = timeText;
 
     const threshold = 26;
     if (score >= threshold) {


### PR DESCRIPTION
## Summary
- séparer le texte principal du score et le texte du temps utilisé
- affecter l'information de temps à l'élément `time-used` tout en conservant les messages de réussite/échec

## Testing
- node - <<'NODE' (simulation de l'appel à `showResults`)

------
https://chatgpt.com/codex/tasks/task_e_68ca8ba9d2b883228f82412f39fbd513