### PR TITLE
Remove redundant getRandomQuestions from main

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -34,15 +34,6 @@ let allQuestions = [];
 let selectedQuestions = [];
 
 /**
- * Fonction utilitaire pour sélectionner aléatoirement un sous-ensemble d'éléments dans un tableau.
- */
-function getRandomQuestions(array, count) {
-    const copy = array.slice();
-    shuffleArray(copy);
-    return copy.slice(0, count);
-}
-
-/**
  * Charge et assemble les questions depuis 6 fichiers JSON (ex : chapt1.json … chapt6.json)
  * La répartition est définie par le nombre de questions à tirer dans chaque fichier.
  *


### PR DESCRIPTION
## Summary
- remove the duplicate getRandomQuestions implementation from main.js so the file uses the shared helper from utils.js

## Testing
- Verified exam start via automated browser script to ensure 40 unique random questions are loaded

------
https://chatgpt.com/codex/tasks/task_e_68ca8bb005608322b58bd679ca69074b