### PR TITLE
Improve error handling when loading chapter JSON files

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -66,6 +66,11 @@ async function loadQuestionsFromMultipleJson() {
 
         for (const dist of distribution) {
             const response = await fetch(dist.file);
+            if (!response.ok) {
+                const errorMessage = `Échec du chargement du fichier ${dist.file} (statut ${response.status})`;
+                console.error(errorMessage);
+                throw new Error(errorMessage);
+            }
             const data = await response.json();
 
             // Pour chaque question, on complète avec les infos du chapitre si disponibles.
@@ -90,6 +95,9 @@ async function loadQuestionsFromMultipleJson() {
         return finalQuestions;
     } catch (error) {
         console.error("Erreur lors du chargement des JSON :", error);
+        if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+            window.alert(`Impossible de charger les questions pour un chapitre : ${error.message}`);
+        }
         return [];
     }
 }


### PR DESCRIPTION
## Summary
- check the HTTP status of each JSON fetch before parsing it
- raise an explicit error when a chapter file cannot be retrieved and surface a user-facing alert

## Testing
- python -m http.server 8000 (manual): renamed a chapter file temporarily and triggered the alert when starting the exam


------
https://chatgpt.com/codex/tasks/task_e_68ca8baf6b688322ac7831c5fd82ecb9