### PR TITLE
Fix Tailwind config detection in input CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 
 # OS
 .DS_Store
+
+# Dépendances et builds
+node_modules/
+dist/

--- a/src/input.css
+++ b/src/input.css
@@ -1,5 +1,3 @@
-@config "../tailwind.config.js";
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- remove the `@config` directive from the Tailwind entry CSS so WebStorm no longer mis-detects the stylesheet as a config file
- ignore generated build artifacts and dependencies in version control for cleaner local worktrees

## Testing
- node scripts/build-tailwind.mjs

------
https://chatgpt.com/codex/tasks/task_e_68ca9189f6c08322b5e8707353af5823